### PR TITLE
fix release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,5 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mackerelio/workflows/.github/workflows/goreleaser.yml@main
+    uses: mackerelio/workflows/.github/workflows/goreleaser.yml@main
+


### PR DESCRIPTION
> reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps